### PR TITLE
proposed change for JB2A free vs Patreon

### DIFF
--- a/module.json
+++ b/module.json
@@ -14,9 +14,6 @@
             "name": "sequencer"
         },
         {
-            "name": "JB2A_DnD5e"
-        },
-        {
             "name": "animated-spell-effects"
         },
         {

--- a/scripts/WeaponFX.js
+++ b/scripts/WeaponFX.js
@@ -35,6 +35,13 @@ function _getTokenByIdOrActorId(id) {
 }
 
 Hooks.once("sequencer.ready", async function () {
+    //Check if either free or Patreon JB2A module is installed and activated, otherwise return and display an error message.
+    if (!game.modules.get('jb2a_patreon')?.active && !game.modules.get('JB2A_DnD5e')?.active){
+        const message = "Lancer Weapon FX | You need either the Free or the Patreon version of JB2A for this module to work properly";
+        console.log(`%c ${message}`, `color: #dc143c`)
+        ui.notifications.error(message);
+        return {}
+    }
     // preload effects data
     await Sequencer.Preloader.preload([
         "jb2a.arrow.physical.blue",


### PR DESCRIPTION
If neither module is found, will scream at the user loudly and prevent the Sequencer preload as not to flood the console with errors
Since all the animations for JB2A are called via the Sequencer database paths, as long as it's compatible with the free pack, it will be compatible with the Patreon pack as well.

It's functional from the tests I've made but this is only a proposal. I understand that a hard dependency should make more sense and splitting our packs between two modules is awkward so I'd understand if you decide to disregard this PR :)