### PR TITLE
Make "missing JB2A" notification permanent until closed

### DIFF
--- a/scripts/WeaponFX.js
+++ b/scripts/WeaponFX.js
@@ -51,13 +51,14 @@ async function _executeMacroByName(
 }
 
 Hooks.once("sequencer.ready", async function () {
-    //Check if either free or Patreon JB2A module is installed and activated, otherwise return and display an error message.
-    if (!game.modules.get('jb2a_patreon')?.active && !game.modules.get('JB2A_DnD5e')?.active){
-        const message = "Lancer Weapon FX | You need either the Free or the Patreon version of JB2A for this module to work properly";
-        console.log(`%c ${message}`, `color: #dc143c`)
-        ui.notifications.error(message);
-        return {}
+    // Check if either free or Patreon JB2A module is installed and activated, otherwise return and display an error message.
+    if (!game.modules.get('jb2a_patreon')?.active && !game.modules.get('JB2A_DnD5e')?.active) {
+        const message = "Lancer Weapon FX | You need either the Free or the Patreon version of JB2A installed and active for this module to work properly!";
+        console.error(`${message} The free version can be found at: https://foundryvtt.com/packages/JB2A_DnD5e`);
+        ui.notifications.error(message, {permanent: true, console: false});
+        return;
     }
+
     // preload effects data
     await Sequencer.Preloader.preload([
         "jb2a.arrow.physical.blue",


### PR DESCRIPTION
- make notification "permanent" (until user closes) to make sure the user has a chance to see it
- use `.error` instead of colored `.log` to pass console filters
- add link to free JB2A to console message
- clean up formatting and return value

Closes #17