### PR TITLE
Implement per-name effect associations for customizability/third-party support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Once installed and activated, weapon FX should "just work" with all attack rolls
 
 ### Manual
 
+#### Macros
+
 The module installs a Macro compendium which you can use to apply effects to attacks manually. The recommended method for applying these FX manually is:
 
 * Find the roll macro button for the weapon you wish to apply FX to and drag it to the Token Hotbar.
@@ -37,5 +39,26 @@ Video demonstration:
 
 ![weaponfxdemo](https://user-images.githubusercontent.com/76132631/155030217-4ee5c47e-00d5-49b8-8601-20117b0e9c08.gif)
 
+#### Editing the list
+
+If you have some technical knowledge, you can manually add custom entries to the list of hardcoded effects. This is useful for accounting for third-party content, which can potentially have many types of features replicated across multiple characters, meaning that managing macros for them could be a hassle.
+
+To do this, navigate to the module's scripts `(Foundry installation directory)/Data/modules/lancer-weapon-fx/scripts` and open `weaponEffects.js` in your text editor of choice; from there you can add new entries as desired. The module checks the name of any given feature before checking its ID, so adding an effect to a weapon is as simple as just entering its name and the associated effect you want.
+
+This example, appended to the bottom of the list, would make any Foundry feature with the name **Example Custom Weapon** use the Assault Rifle effect in the macro compendium when attacking:
+
+```
+    "Example Custom Weapon": "Assault Rifle",
+```
+
+You can add as many as you like:
+
+```
+    "Example Custom Weapon": "Assault Rifle",
+    "Data Dart": "Nexus",
+    "Gun That Makes You Stabilize": "Stabilize",
+```
+
+---
 
 I am not a professional by any means and am open to suggestions and critiques.  I would love to improve this product and add new FX so please don't hesitate to leave a suggestion.

--- a/scripts/WeaponFX.js
+++ b/scripts/WeaponFX.js
@@ -130,12 +130,25 @@ Hooks.on("createChatMessage", (data) => {
 
     const {weaponObject, weaponIdentifier, sourceToken} = messageMeta;
 
-    // Check for any custom/user-defined macros first
-    var macroName = weaponEffects[weaponObject?.system.name];
-    if (!macroName)
+    var macroName;
+
+    // weaponObject can variously be either an object with Foundry item data, or a string
+    // We use strings as a fallback, so that we can have effects for itemless actions (stabilizing, tech attacks, etc)
+    if (weaponObject instanceof Object)
     {
-        // If we don't find them, only then do we check the hardcoded ones
-        macroName = weaponEffects[weaponIdentifier];
+        // Check for any custom/user-defined macros first by checking the name of the object
+        macroName = weaponEffects[weaponObject?.system.name];
+        if (!macroName)
+        {
+            // If we don't find them, then we check the hardcoded list
+            macroName = weaponEffects[weaponObject?.system.lid];
+            if (!macroName)
+                return;
+        }
+    }
+    else
+    {
+        macroName = weaponEffects[weaponObject];
         if (!macroName)
             return;
     }

--- a/scripts/WeaponFX.js
+++ b/scripts/WeaponFX.js
@@ -128,27 +128,27 @@ Hooks.on("createChatMessage", (data) => {
     const messageMeta = getMessageInfo(data);
     if (messageMeta == null) return;
 
-    const {weaponObject, weaponIdentifier, sourceToken} = messageMeta;
+    const {weaponIdentifier, sourceToken} = messageMeta;
 
     var macroName;
 
-    // weaponObject can variously be either an object with Foundry item data, or a string
+    // weaponIdentifier can variously be either an object with Foundry item data, or a string
     // We use strings as a fallback, so that we can have effects for itemless actions (stabilizing, tech attacks, etc)
-    if (weaponObject instanceof Object)
+    if (weaponIdentifier instanceof Object)
     {
         // Check for any custom/user-defined macros first by checking the name of the object
-        macroName = weaponEffects[weaponObject?.system.name];
+        macroName = weaponEffects[weaponIdentifier?.system.name];
         if (!macroName)
         {
             // If we don't find them, then we check the hardcoded list
-            macroName = weaponEffects[weaponObject?.system.lid];
+            macroName = weaponEffects[weaponIdentifier?.system.lid];
             if (!macroName)
                 return;
         }
     }
     else
     {
-        macroName = weaponEffects[weaponObject];
+        macroName = weaponEffects[weaponIdentifier];
         if (!macroName)
             return;
     }

--- a/scripts/WeaponFX.js
+++ b/scripts/WeaponFX.js
@@ -128,10 +128,17 @@ Hooks.on("createChatMessage", (data) => {
     const messageMeta = getMessageInfo(data);
     if (messageMeta == null) return;
 
-    const {weaponIdentifier, sourceToken} = messageMeta;
+    const {weaponObject, weaponIdentifier, sourceToken} = messageMeta;
 
-    const macroName = weaponEffects[weaponIdentifier];
-    if (!macroName) return;
+    // Check for any custom/user-defined macros first
+    var macroName = weaponEffects[weaponObject?.system.name];
+    if (!macroName)
+    {
+        // If we don't find them, only then do we check the hardcoded ones
+        macroName = weaponEffects[weaponIdentifier];
+        if (!macroName)
+            return;
+    }
 
     console.log("Lancer Weapon FX | Found macro '" + macroName + "' for weapon '" + weaponIdentifier + "', playing animation");
     _executeMacroByName(macroName, sourceToken, {messageId: data._id}).then(null);

--- a/scripts/messageParser.js
+++ b/scripts/messageParser.js
@@ -3,13 +3,11 @@ class MessageInfo {
         {
             sourceToken,
             weaponObject,
-            weaponIdentifier,
             targetTokens = null,
             targetsMissed = new Set(),
         }
     ) {
         this.sourceToken = sourceToken;
-        this.weaponIdentifier = weaponIdentifier;
         this.weaponObject = weaponObject;
         this.targetTokens = targetTokens;
         this.targetsMissed = targetsMissed;
@@ -69,7 +67,7 @@ export function getMessageInfo (data) {
             console.log("it's a stabilize!!");
             return new MessageInfo({
                 sourceToken: _getTokenByIdOrActorId(data.speaker.actor),
-                weaponIdentifier: "lwfx_stabilize",
+                weaponObject: "lwfx_stabilize",
             })
         }
 
@@ -85,7 +83,6 @@ export function getMessageInfo (data) {
         return new MessageInfo({
             sourceToken,
             weaponObject: sourceToken.actor.items.get(weaponItemId),
-            weaponIdentifier: sourceToken.actor.items.get(weaponItemId)?.system.lid,
             targetTokens,
             targetsMissed: _getTargetsMissed(chatMessage, targets),
         });
@@ -96,7 +93,7 @@ export function getMessageInfo (data) {
 
         return new MessageInfo({
             sourceToken: _getTokenByIdOrActorId(sourceInfo),
-            weaponIdentifier: "default_tech_attack",
+            weaponObject: "default_tech_attack",
             targetTokens: targets.map(t =>_getTokenByIdOrActorId(t.target_id)),
             targetsMissed: _getTargetsMissed(chatMessage, targets),
         })
@@ -114,7 +111,7 @@ export function getMessageInfo (data) {
 
         return new MessageInfo({
             sourceToken,
-            weaponIdentifier: "default_tech_attack",
+            weaponObject: "default_tech_attack",
             targetTokens: targets.map(t =>_getTokenByIdOrActorId(t.target_id)),
             targetsMissed: _getTargetsMissed(chatMessage, targets),
         });

--- a/scripts/messageParser.js
+++ b/scripts/messageParser.js
@@ -2,13 +2,13 @@ class MessageInfo {
     constructor (
         {
             sourceToken,
-            weaponObject,
+            weaponIdentifier,
             targetTokens = null,
             targetsMissed = new Set(),
         }
     ) {
         this.sourceToken = sourceToken;
-        this.weaponObject = weaponObject;
+        this.weaponIdentifier = weaponIdentifier;
         this.targetTokens = targetTokens;
         this.targetsMissed = targetsMissed;
     }
@@ -67,7 +67,7 @@ export function getMessageInfo (data) {
             console.log("it's a stabilize!!");
             return new MessageInfo({
                 sourceToken: _getTokenByIdOrActorId(data.speaker.actor),
-                weaponObject: "lwfx_stabilize",
+                weaponIdentifier: "lwfx_stabilize",
             })
         }
 
@@ -82,7 +82,7 @@ export function getMessageInfo (data) {
         const targetTokens = targets.map(t =>_getTokenByIdOrActorId(t.target_id));
         return new MessageInfo({
             sourceToken,
-            weaponObject: sourceToken.actor.items.get(weaponItemId),
+            weaponIdentifier: sourceToken.actor.items.get(weaponItemId),
             targetTokens,
             targetsMissed: _getTargetsMissed(chatMessage, targets),
         });
@@ -93,7 +93,7 @@ export function getMessageInfo (data) {
 
         return new MessageInfo({
             sourceToken: _getTokenByIdOrActorId(sourceInfo),
-            weaponObject: "default_tech_attack",
+            weaponIdentifier: "default_tech_attack",
             targetTokens: targets.map(t =>_getTokenByIdOrActorId(t.target_id)),
             targetsMissed: _getTargetsMissed(chatMessage, targets),
         })
@@ -111,7 +111,7 @@ export function getMessageInfo (data) {
 
         return new MessageInfo({
             sourceToken,
-            weaponObject: "default_tech_attack",
+            weaponIdentifier: "default_tech_attack",
             targetTokens: targets.map(t =>_getTokenByIdOrActorId(t.target_id)),
             targetsMissed: _getTargetsMissed(chatMessage, targets),
         });

--- a/scripts/messageParser.js
+++ b/scripts/messageParser.js
@@ -2,6 +2,7 @@ class MessageInfo {
     constructor (
         {
             sourceToken,
+            weaponObject,
             weaponIdentifier,
             targetTokens = null,
             targetsMissed = new Set(),
@@ -9,6 +10,7 @@ class MessageInfo {
     ) {
         this.sourceToken = sourceToken;
         this.weaponIdentifier = weaponIdentifier;
+        this.weaponObject = weaponObject;
         this.targetTokens = targetTokens;
         this.targetsMissed = targetsMissed;
     }
@@ -82,6 +84,7 @@ export function getMessageInfo (data) {
         const targetTokens = targets.map(t =>_getTokenByIdOrActorId(t.target_id));
         return new MessageInfo({
             sourceToken,
+            weaponObject: sourceToken.actor.items.get(weaponItemId),
             weaponIdentifier: sourceToken.actor.items.get(weaponItemId)?.system.lid,
             targetTokens,
             targetsMissed: _getTargetsMissed(chatMessage, targets),

--- a/scripts/weaponEffects.js
+++ b/scripts/weaponEffects.js
@@ -196,7 +196,26 @@ const weaponEffects = {
     "npc_Leech_PairedTalonsMKII": "Plasma Talons",
     "npc_Tempest_NaniteMonsoonDispensers": "Nexus",
     "npc_Tempest_TyphoonNaniteCannon": "Nexus",
-    "npc_PDCTurret": "Leviathan"
+    "npc_PDCTurret": "Leviathan",
+
+    /*
+    Custom effects go under here. You can associate the name of a feature in Foundry to the name of a macro in the compendium, like so:
+
+        "Data Dart": "Nexus"
+        "Anticausal Thought": "Displacer"
+        "Example Custom Weapon": "Assault Rifle",
+
+    If your feature has quotes in the name, use backslashes (\) to prevent issues:
+
+        "\"Hornet\" Light Submachine Gun": "Assault Rifle",
+
+    If there aren't any effects you like, you can unlock the compendium and add your own.
+    If Foundry is open, refreshing the window will reflect changes made here; you don't need to reload the world.
+
+    !! BACK UP YOUR CHANGES BEFORE A MODULE UPDATE OR THEY'LL BE LOST !!
+    */
+    "Example Custom Weapon": "Assault Rifle",
+    "\"SPAGHETTI\" Weaponized JavaScript Module": "DefaultTech"
     };
 
 export { weaponEffects };

--- a/scripts/weaponEffects.js
+++ b/scripts/weaponEffects.js
@@ -215,7 +215,7 @@ const weaponEffects = {
     !! BACK UP YOUR CHANGES BEFORE A MODULE UPDATE OR THEY'LL BE LOST !!
     */
     "Example Custom Weapon": "Assault Rifle",
-    "\"SPAGHETTI\" Weaponized JavaScript Module": "DefaultTech"
+    "\"SPAGHETTI\" Weaponized JavaScript Module": "DefaultTech",
     };
 
 export { weaponEffects };


### PR DESCRIPTION
**purpose**

due to the way it's set up, the module doesn't really account for third-party content in a clean way. big popular third-party supplements like Field Guide to Suldan can have many different features, and setting up a macro for each individual one could be a lot of overhead to manage, especially for custom stuff that multiple PCs have. we certainly can't account for the infinite breadth of possible homebrews, but we *can* make it easier to extend!

**details**

this modifies the module's system to first attempt to find an appropriate effect macro by searching using a feature's Foundry name; only if it doesn't find anything will it use the item's ID instead. users can manually edit `weaponEffects.js` (in a specially designated section for cleanliness) to add effect associations by simply using the name of the feature and the associated effect they want. for instance, if I had my gun `Big Gun` and I wanted to give it the LHAC effect, adding it would be as simple as:

```
    "Big Gun": "Leviathan",
```

there are a few main use cases for this:
* accounting for third-party content that many players might have at once without having to manage a macro for every feature/weapon
* accounting for items made in Foundry directly (i.e. not from an lcp/compendium), whose IDs can be a bit painstaking to get
* character-specific overrides on their weapons

---

key back-end changes:
* `weaponIdentifier` variable can now be an `Object` reference as well as a string
* revamped macro selection: `weaponIdentifier` is first checked if it's an `Object`: if so, it checks `weaponIdentifier.system.name` for name-specific entries, and if that fails, it checks `weaponIdentifier.system.lid` (mirroring the existing functionality)
	* if it isn't an object, it searches `weaponEffects[weaponIdentifier]` directly, since if it's not an `Object` then it must be a string. we do this to maintain functionality for itemless effects such as stabilizing and tech attacks, which pass a relevant effect ID directly

my javascript knowledge is sorely lacking and this is, as far as I can tell, some of my first work with it in an open source project. it might be pretty messy -- please feel free to let me know what problems there with the code or with the approach itself. I think it'd be ideal to have this doable from in-game through a settings menu, but this is unfortunately currently beyond my skillset to pull off