### PR TITLE
Add "recommends" module IDs to module.json

### DIFF
--- a/module.json
+++ b/module.json
@@ -28,6 +28,16 @@
                     "minimum": "2.3.7"
                 }
             }
+        ],
+        "recommends": [
+            {
+                "id": "jb2a_patreon",
+                "type": "module"
+            },
+            {
+                "id": "JB2A_DnD5e",
+                "type": "module"
+            }
         ]
     },
     "languages": [


### PR DESCRIPTION
The "recommends" relationship gives the user an optional prompt when activating the module, giving a reminder to activate one of the JB2A modules without forcing an explicit dependency.

![image](https://github.com/Z3nner/lancer-weapon-fx/assets/9784519/81b59f8f-1871-408c-8d13-42b882c16066)

The use can then select which (if any(!?)) JB2A module they wish to activate alongside the module.