### PR TITLE
Use case- and whitespace-insensitive search for macros

### DIFF
--- a/scripts/effectResolver/effectResolver.js
+++ b/scripts/effectResolver/effectResolver.js
@@ -12,7 +12,10 @@ const _pGetLwfxMacroUuid = async macroName => {
         return null;
     }
 
-    const macro = (await pack.getDocuments()).find(doc => doc.name === macroName);
+    // Case- and whitespace-insensitive search
+    const macroSearchName = macroName.toLowerCase().trim();
+    const macro = (await pack.getDocuments()).find(doc => doc.name.toLowerCase().trim() === macroSearchName);
+
     if (!macro) {
         ui.notifications.error(`Lancer Weapon FX | Macro ${macroName} not found`);
         return null;


### PR DESCRIPTION
We never expect to have two different macros with the same "name" but different casing or leading/trailing whitespace. Therefore, ignore case and leading/trailing whitespace when finding macros.