### PR TITLE
Allow effects folders to have an actor assigned

### DIFF
--- a/css/effects-manager.css
+++ b/css/effects-manager.css
@@ -36,12 +36,33 @@
     font-weight: 700;
     text-transform: uppercase;
     border: 0;
+    text-align: left;
 }
 
 .lancer.app input.lwfx-effects-manager__ipt-folder-name[type="text"]::placeholder {
     color: color-mix(in srgb, var(--light-text), var(--dark-text) 27%);
     font-style: italic;
     font-weight: initial;
+}
+
+.lwfx-effects-manager__wrp-actor-link {
+    border: 1px solid var(--darken-3);
+    border-radius: 5px;
+    padding: .25em;
+    background: var(--light-gray-color);
+    color: var(--dark-text);
+}
+
+a.lwfx-effects-manager__actor-link {
+    padding: 1px calc(0.5 * var(--lwfx-spacer));
+    flex: unset;
+    color: var(--light-text);
+    border-color: var(--darken-3);
+    background: var(--dark-gray-color);
+}
+
+a.lwfx-effects-manager__actor-link i {
+    color: var(--dark-text);
 }
 
 /* -------------------------------------------- */

--- a/css/helpers.css
+++ b/css/helpers.css
@@ -129,9 +129,18 @@
     margin-right: calc(0.5 * var(--lwfx-spacer)) !important;
 }
 
+.lwfx__mx-2 {
+    margin-left: var(--lwfx-spacer) !important;
+    margin-right: var(--lwfx-spacer) !important;
+}
+
 .lwfx__my-1 {
     margin-top: calc(0.5 * var(--lwfx-spacer)) !important;
     margin-bottom: calc(0.5 * var(--lwfx-spacer)) !important;
+}
+
+.lwfx__mr-0 {
+    margin-right: 0 !important;
 }
 
 .lwfx__mr-1 {
@@ -148,6 +157,10 @@
 
 .lwfx__ml-1 {
     margin-left: calc(0.5 * var(--lwfx-spacer)) !important;
+}
+
+.lwfx__ml-2 {
+    margin-left: var(--lwfx-spacer) !important;
 }
 
 .lwfx__pr-2 {

--- a/lang/en.json
+++ b/lang/en.json
@@ -44,7 +44,9 @@
                 "Multiple Effects Item Name Hint": "Multiple effects exist with this item name!",
                 "Multiple Effects Lancer ID Hint": "Multiple effects exist with this Lancer ID!",
                 "Start Tour": "Start Tour",
-                "Usage Hint": "Drag-and-drop an Item or Macro to create a new effect."
+                "Usage Hint": "Drag-and-drop an Item or Macro to create a new effect.",
+                "Folder No Actor Hint": "Effects in this folder will be used by every actor. To instead restrict the use of these effects to a single actor, drag-and-drop an Actor to this folder.",
+                "Unlink Actor": "Unlink Actor"
             },
 
             "fields": {

--- a/scripts/effectManager/models.js
+++ b/scripts/effectManager/models.js
@@ -9,6 +9,13 @@ export const schemaFolder = new foundry.data.fields.SchemaField({
         label: "Name",
     }),
 
+    // TODO(v12) switch to `foundry.data.fields.DocumentUUIDField`
+    actorUuid: new foundry.data.fields.StringField({
+        type: "Actor",
+        label: "lancer-weapon-fx.effectManager.fields.actorUuid.label",
+        nullable: true,
+    }),
+
     isCollapsed: new foundry.data.fields.BooleanField({
         initial: false,
     }),

--- a/scripts/effectResolver/effectResolverCustom.js
+++ b/scripts/effectResolver/effectResolverCustom.js
@@ -1,0 +1,97 @@
+import { getSearchString } from "../utils.js";
+import { MODULE_ID } from "../consts.js";
+import { SETTING_EFFECTS_MANAGER_STATE } from "../settings.js";
+
+const _TYPE_STRONG = "strong";
+const _TYPE_WEAK = "weak";
+const _TYPE_NONE = "none";
+
+// Prefer effects with folders, as we want effects with actors (which are stored at the folder level)
+//   to take precedent over generic effects.
+const _sortCustomEffects = (effectA, effectB) => Number(!!effectB.folderId) - Number(!!effectA.folderId);
+
+const _getEffectActorUuidMatchType = ({ actorUuid, effect, customState }) => {
+    if (actorUuid == null || effect.folderId == null) return _TYPE_WEAK;
+
+    const effectActorUuid = customState.folders[effect.folderId]?.actorUuid;
+    if (effectActorUuid == null) return _TYPE_WEAK;
+
+    if (effectActorUuid === actorUuid) return _TYPE_STRONG;
+
+    return _TYPE_NONE;
+};
+
+const _getActorSpecificCandidateEffects = ({ actorUuid, customState, candidateEffects }) => {
+    const typed = {};
+
+    candidateEffects.forEach(effect => {
+        (typed[_getEffectActorUuidMatchType({ actorUuid, effect, customState })] ||= []).push(effect);
+    });
+
+    if (typed[_TYPE_STRONG]?.length) return typed[_TYPE_STRONG];
+    if (typed[_TYPE_WEAK]?.length) return typed[_TYPE_WEAK];
+    return [];
+};
+
+const _getCustomMacroUuidByItemLid = ({ actorUuid, itemLid, customState }) => {
+    const itemLidSearch = getSearchString(itemLid);
+    if (!itemLidSearch) return null;
+
+    const candidateEffects = Object.values(customState.effects)
+        .sort(_sortCustomEffects)
+        // `.filter` instead of `.find` so we can warn if multiple matches
+        .filter(effect => getSearchString(effect.itemLid) === itemLid && getSearchString(effect.macroUuid));
+
+    const byLid = _getActorSpecificCandidateEffects({
+        actorUuid,
+        customState,
+        candidateEffects,
+    });
+
+    if (!byLid.length) return null;
+
+    const [{ macroUuid }] = byLid;
+    if (byLid.length === 1) return macroUuid;
+
+    ui.notifications.warn(`Multiple custom effects found for Lancer ID "${itemLid}"!`);
+
+    return macroUuid;
+};
+
+const _getCustomMacroUuidByItemName = ({ actorUuid, itemName, customState }) => {
+    const itemNameSearch = getSearchString(itemName);
+    if (!itemNameSearch) return null;
+
+    const candidateEffects = Object.values(customState.effects)
+        .sort(_sortCustomEffects)
+        // `.filter` instead of `.find` so we can warn if multiple matches
+        .filter(effect => getSearchString(effect.itemName) === itemNameSearch && getSearchString(effect.macroUuid));
+
+    const byName = _getActorSpecificCandidateEffects({
+        actorUuid,
+        customState,
+        candidateEffects,
+    });
+
+    if (!byName.length) return null;
+
+    const [{ macroUuid }] = byName;
+    if (byName.length === 1) return macroUuid;
+
+    ui.notifications.warn(`Multiple custom effects found for Item Name "${itemName}"!`);
+
+    return macroUuid;
+};
+
+export const getCustomMacroUuid = ({ actorUuid, itemLid, itemName = null }) => {
+    const customState = game.settings.get(MODULE_ID, SETTING_EFFECTS_MANAGER_STATE);
+    if (!Object.keys(customState?.effects || {}).length) return null;
+
+    const byLid = _getCustomMacroUuidByItemLid({ actorUuid, itemLid, customState });
+    if (byLid) return byLid;
+
+    const byName = _getCustomMacroUuidByItemName({ actorUuid, itemName, customState });
+    if (byName) return byName;
+
+    return null;
+};

--- a/scripts/flow/flowListener.js
+++ b/scripts/flow/flowListener.js
@@ -20,7 +20,13 @@ const _pGetFlowInfo = async (state, { fallbackActionIdentifier = null } = {}) =>
 
     return new FlowInfo({
         sourceToken: getTokenByIdOrActorId(state.actor.token?.id || state.actor?.id),
-        macroUuid: await pGetMacroUuid(state.item?.system?.lid, state.item?.name, fallbackActionIdentifier),
+        macroUuid: await pGetMacroUuid({
+            // Prefer the token base actor, if available. This ensures linking for synthetic (NPC token) actors.
+            actorUuid: state.actor?.token?.baseActor?.uuid || state.actor?.uuid,
+            itemLid: state.item?.system?.lid,
+            itemName: state.item?.name,
+            fallbackActionIdentifier,
+        }),
         targetTokens: zippedTargetInfo.map(({ target }) => target.target).filter(Boolean),
         targetsMissed: new Set(
             zippedTargetInfo

--- a/templates/effectManager/partial/folder-row.hbs
+++ b/templates/effectManager/partial/folder-row.hbs
@@ -37,8 +37,21 @@
             name="folders.{{folder.id}}.name"
             value="{{folder.name}}"
             placeholder="{{localize "lancer-weapon-fx.effectManager.app.Folder Name"}}"
-            class="lwfx__w-100 lwfx__mr-1 lwfx-effects-manager__ipt-folder-name submajor"
+            class="lwfx__w-100 lwfx-effects-manager__ipt-folder-name lwfx__mr-0 submajor"
         >
+
+        {{#if folder.actorUuid}}
+            <div class="lwfx-effects-manager__wrp-actor-link lwfx__flexrow-v-center lwfx__ws-nowrap lwfx__ml-2 lwfx__mr-1 lwfx__h-100">
+                {{{folder.actorLink}}}
+                <a
+                    class="fas fa-user-slash fa-fw lwfx__fa lwfx__fa-fw lwfx__ml-2 lwfx__mr-1"
+                    data-name="btn-folder-actor-unlink"
+                    data-tooltip="{{localize "lancer-weapon-fx.effectManager.app.Unlink Actor"}}"
+                ></a>
+            </div>
+        {{else}}
+            <i class="lwfx__mx-2 fas fa-users fa-fw lwfx__fa lwfx__fa-fw" data-tooltip="{{localize "lancer-weapon-fx.effectManager.app.Folder No Actor Hint"}}"></i>
+        {{/if}}
 
         <button
             type="button"

--- a/tours/effect-manager.json
+++ b/tours/effect-manager.json
@@ -19,6 +19,18 @@
             "id": "3",
             "title": "lancer-weapon-fx.effectManager.tour.Step 3 Title",
             "content": "lancer-weapon-fx.effectManager.tour.Step 3 Content"
+        },
+        {
+            "id": "4",
+            "selector": "[data-tour-tag=\"lwfx-dropzone\"]",
+            "title": "lancer-weapon-fx.effectManager.tour.Step 4 Title",
+            "content": "lancer-weapon-fx.effectManager.tour.Step 4 Content"
+        },
+        {
+            "id": "5",
+            "selector": "[data-tour-tag=\"lwfx-dropzone\"]",
+            "title": "lancer-weapon-fx.effectManager.tour.Step 5 Title",
+            "content": "lancer-weapon-fx.effectManager.tour.Step 5 Content"
         }
     ],
     "localization": {
@@ -29,6 +41,10 @@
         "lancer-weapon-fx.effectManager.tour.Step 2 Title": "Modifying Effects",
         "lancer-weapon-fx.effectManager.tour.Step 2 Content": "Drag-and-drop an Item or Macro to an effect to update that effect.",
         "lancer-weapon-fx.effectManager.tour.Step 3 Title": "Effect Precedence",
-        "lancer-weapon-fx.effectManager.tour.Step 3 Content": "Custom effects will take precedence over built-in effects."
+        "lancer-weapon-fx.effectManager.tour.Step 3 Content": "Custom effects will take precedence over built-in effects.",
+        "lancer-weapon-fx.effectManager.tour.Step 4 Title": "Folders",
+        "lancer-weapon-fx.effectManager.tour.Step 4 Content": "Effects can be organized into folders. Drag-and-drop an effect to move it into a folder.",
+        "lancer-weapon-fx.effectManager.tour.Step 5 Title": "Actor-Specific Effects",
+        "lancer-weapon-fx.effectManager.tour.Step 5 Content": "Drag-and-drop an Actor to a folder to link the Actor to that folder. Effects in the folder will only be played for the linked actor."
     }
 }


### PR DESCRIPTION
When an actor is assigned to a folder, an effect in that folder will only be used if that actor is the one triggering the FX.

Some additional specifics:

- When multiple effects are defined for a single LID/Name, the effects are "de-duplicated" according to their actor assignation. Therefore, multiple effects can be defined for the same LID/Name without conflicting, so long as each effect is in a folder with a different actor.
- When selecting an effect, if a flow has both any-actor and actor-specific effects, the actor-specific effects will be preferred. This allows the user to customize the FX for a LID/Name generally, and then add a specific override for an actor.
- For NPCs, we link folders to the "base actor." This ensures that any synthetic actors derived from that actor (NPC tokens) use the effects configured for the base actor.

---

Effects defined for an actor take precedence (here, Mech 1 has "Stabilize" as their AR. Mech 2 has "DefaultMelee" as their AR):

[actor-specific-vs-general.webm](https://github.com/user-attachments/assets/c4bfedb9-44d8-4e60-894b-1c47261b2aa3)

Linking and un-linking an actor; duplicate checks are done per-actor:

[actor-link-unlink.webm](https://github.com/user-attachments/assets/93ed3a75-0389-4acf-90b8-1f037f3adbc8)

NPC "synthetic actors" use the effects assigned to their base actor:

[npc.webm](https://github.com/user-attachments/assets/5b24d4f3-1d2e-446a-8b75-e79744fb671f)
