### PR TITLE
Correctly fetch effect filenames for measured template texture updates

### DIFF
--- a/packs_source/weaponfx/Effects (Manual)/Designate_Pinaka_Area_D8E9YpHQsJhxBLvs.js
+++ b/packs_source/weaponfx/Effects (Manual)/Designate_Pinaka_Area_D8E9YpHQsJhxBLvs.js
@@ -8,7 +8,7 @@ game.lancer.canvas.WeaponRangeTemplate.fromRange({
     .then(t => {
         if (t) {
             t.update({
-                texture: "jb2a.zoning.inward.square.loop.bluegreen.01.01",
+                texture: Sequencer.Database.getEntry("jb2a.zoning.inward.square.loop.bluegreen.01.01").file,
                 distance: 1,
                 fillColor: "#FF0000",
             });

--- a/packs_source/weaponfx/Effects (Manual)/Designate_Smoke_Grenade_ZNQDndUit13iQDfV.js
+++ b/packs_source/weaponfx/Effects (Manual)/Designate_Smoke_Grenade_ZNQDndUit13iQDfV.js
@@ -8,7 +8,7 @@ game.lancer.canvas.WeaponRangeTemplate.fromRange({
     .then(t => {
         if (t) {
             t.update({
-                texture: "jb2a.smoke.plumes_loop.01.grey.2",
+                texture: Sequencer.Database.getEntry("jb2a.smoke.plumes_loop.01.grey.2").file,
                 distance: 1.8,
                 fillColor: "#756c6c",
             });

--- a/packs_source/weaponfx/Effects (Manual)/Designate_Smoke_Mine_EiG9UfyeoHsXCX3L.js
+++ b/packs_source/weaponfx/Effects (Manual)/Designate_Smoke_Mine_EiG9UfyeoHsXCX3L.js
@@ -8,7 +8,7 @@ game.lancer.canvas.WeaponRangeTemplate.fromRange({
     .then(t => {
         if (t) {
             t.update({
-                texture: "jb2a.smoke.plumes_loop.01.grey.2",
+                texture: Sequencer.Database.getEntry("jb2a.smoke.plumes_loop.01.grey.2").file,
                 distance: 2.8,
                 fillColor: "#756c6c",
             });


### PR DESCRIPTION
Fixes a regression introduced in #61 where Sequencer Database paths were being used instead of file paths. The intent of the change was good, but the implementation was incomplete. Add the missing step to fetch a real file path from Sequencer.

Closes #65.