### PR TITLE
Catch bad folder IDs earlier and add more data validation

### DIFF
--- a/scripts/effectManager/app.js
+++ b/scripts/effectManager/app.js
@@ -464,8 +464,7 @@ export class EffectManagerApp extends FormApplication {
     /* ----- */
 
     async _handleClick_folderExpandCollapse(evt) {
-        const eleFolder = evt.currentTarget.closest("[data-folder-id]");
-        const folderId = eleFolder?.getAttribute("data-folder-id");
+        const folderId = evt.currentTarget.closest("[data-folder-id]")?.getAttribute("data-folder-id");
         if (!folderId) throw new Error("Should never occur!");
 
         await this._updateObject(null, {
@@ -488,6 +487,7 @@ export class EffectManagerApp extends FormApplication {
         evt.stopPropagation();
 
         const folderId = evt.currentTarget.closest("[data-folder-id]").getAttribute("data-folder-id");
+        if (!folderId) throw new Error("Should never occur!");
 
         await this._updateObject(null, {
             [`folders.${folderId}`]: {
@@ -498,6 +498,7 @@ export class EffectManagerApp extends FormApplication {
 
     async _handleClick_folderDelete(evt) {
         const folderId = evt.currentTarget.closest("[data-folder-id]").getAttribute("data-folder-id");
+        if (!folderId) throw new Error("Should never occur!");
 
         await this._updateObject(null, {
             [`folders.-=${folderId}`]: null,
@@ -697,6 +698,7 @@ export class EffectManagerApp extends FormApplication {
         // If dropped to an existing row, update that row
         if (eleFolder) {
             const folderId = eleFolder.getAttribute("data-folder-id");
+            if (!folderId) throw new Error("Should never occur!");
 
             return this._updateObject(null, {
                 [`folders.${folderId}.actorUuid`]: actor.uuid,

--- a/scripts/effectManager/models.js
+++ b/scripts/effectManager/models.js
@@ -77,22 +77,28 @@ export class EffectManagerData extends foundry.abstract.DataModel {
             effects: new foundry.data.fields.ObjectField({
                 initial: () => ({}),
                 validate: (value, options) => {
-                    return Object.values(value).every(obj => {
-                        const isValid = schemaCustomEffect.validate(obj, options);
-                        if (isValid === undefined) return true;
-                        return isValid;
-                    });
+                    return (
+                        Object.keys(value).every(id => id != null && id.trim()) &&
+                        Object.values(value).every(obj => {
+                            const isValid = schemaCustomEffect.validate(obj, options);
+                            if (isValid === undefined) return true;
+                            return isValid;
+                        })
+                    );
                 },
             }),
 
             folders: new foundry.data.fields.ObjectField({
                 initial: () => ({}),
                 validate: (value, options) => {
-                    return Object.values(value).every(obj => {
-                        const isValid = schemaFolder.validate(obj, options);
-                        if (isValid === undefined) return true;
-                        return isValid;
-                    });
+                    return (
+                        Object.keys(value).every(id => id != null && id.trim()) &&
+                        Object.values(value).every(obj => {
+                            const isValid = schemaFolder.validate(obj, options);
+                            if (isValid === undefined) return true;
+                            return isValid;
+                        })
+                    );
                 },
             }),
         };


### PR DESCRIPTION
Relates to #67 but is not a fix. Issue #67 is caused by a missing (empty string) folder ID, which should logically never occur, but clearly is possible. In order to narrow down the places where the bad data is being introduced, add more folder ID checks on user input actions.