### PR TITLE
Use correct LID casing when searching for matching effect

### DIFF
--- a/scripts/effectResolver/effectResolverCustom.js
+++ b/scripts/effectResolver/effectResolverCustom.js
@@ -40,7 +40,7 @@ const _getCustomMacroUuidByItemLid = ({ actorUuid, itemLid, customState }) => {
     const candidateEffects = Object.values(customState.effects)
         .sort(_sortCustomEffects)
         // `.filter` instead of `.find` so we can warn if multiple matches
-        .filter(effect => getSearchString(effect.itemLid) === itemLid && getSearchString(effect.macroUuid));
+        .filter(effect => getSearchString(effect.itemLid) === itemLidSearch && getSearchString(effect.macroUuid));
 
     const byLid = _getActorSpecificCandidateEffects({
         actorUuid,


### PR DESCRIPTION
Compare lowercase LID with lowercase LID, instead of any-case LID with lowercase LID.