### PR TITLE
Add minimum socketlib to required modules

### DIFF
--- a/module.json
+++ b/module.json
@@ -30,6 +30,14 @@
                 "compatibility": {
                     "minimum": "2.3.7"
                 }
+            },
+            {
+                "id": "socketlib",
+                "type": "module",
+                "manifest": "https://github.com/farling42/foundryvtt-socketlib/releases/latest/download/module.json",
+                "compatibility": {
+                    "minimum": "1.1.0"
+                }
             }
         ],
         "recommends": [


### PR DESCRIPTION
This module requires socketlib, but it isn't listed and the version that this module requires is 1.1.x. There are a lot of users on Pilot NET that have a 1.0.x version of socketlib that have expressed woes on this module not working (e.g. `executeForEveryone` does not exist in 1.0.x), and there are likely more that are not on Pilot NET that have had the same problem at some point:

https://discord.com/channels/426286410496999425/760966283545673730/1367671636622442586
https://discord.com/channels/426286410496999425/760966283545673730/1367480278569979905
https://discord.com/channels/426286410496999425/760966283545673730/1356388879946481837

I've confirmed personally that the latest 1.0.x version (1.0.10) does not work and that the minimum this module requires is 1.1.0 or above. As of writing, the current version is 1.1.2.