### PR TITLE
Ensure stable missile color, and add manual Divine Punishment macro

### DIFF
--- a/packs_source/weaponfx/Effects (Manual)/DivinePunishment_HuT2nQAgESxzj5wG.js
+++ b/packs_source/weaponfx/Effects (Manual)/DivinePunishment_HuT2nQAgESxzj5wG.js
@@ -10,10 +10,11 @@ await Sequencer.Preloader.preloadForClients([
     "modules/lancer-weapon-fx/soundfx/Missile_Impact.ogg",
 ]);
 
-let sequence = new Sequence();
-
-for (let i = 0; i < targetTokens.length; i++) {
-    let target = targetTokens[i];
+const sequences = targetTokens.map((target, i) => {
+    const sequence = new Sequence();
+    if (i) {
+        sequence.wait(175 * i);
+    }
     sequence
         .sound()
             .file("modules/lancer-weapon-fx/soundfx/Missile_Launch.ogg")
@@ -31,14 +32,14 @@ for (let i = 0; i < targetTokens.length; i++) {
             .atLocation(sourceToken)
             .stretchTo(target)
             .missed(targetsMissed.has(target.id))
-            .name(`impact${i}`)
+            .name("impact")
             .waitUntilFinished(-3200);
     sequence
         .effect()
             .xray(game.modules.get("lancer-weapon-fx").api.isEffectIgnoreFogOfWar())
             .aboveInterface(game.modules.get("lancer-weapon-fx").api.isEffectIgnoreLightingColoration())
             .file("jb2a.explosion.01.orange")
-            .atLocation(`impact${i}`)
+            .atLocation("impact")
             .scale(0.8)
             .zIndex(1)
             .waitUntilFinished(-1300);
@@ -50,5 +51,7 @@ for (let i = 0; i < targetTokens.length; i++) {
                 .volume(game.modules.get("lancer-weapon-fx").api.getEffectVolume(0.5))
                 .waitUntilFinished(-8500);
     }
-}
-sequence.play();
+    return sequence.play();
+});
+
+await Promise.all(sequences);

--- a/packs_source/weaponfx/Effects (Manual)/DivinePunishment_HuT2nQAgESxzj5wG.json
+++ b/packs_source/weaponfx/Effects (Manual)/DivinePunishment_HuT2nQAgESxzj5wG.json
@@ -1,0 +1,10 @@
+{
+    "_id": "HuT2nQAgESxzj5wG",
+    "name": "DivinePunishment",
+    "type": "script",
+    "img": "modules/lancer-weapon-fx/icons/missile-swarm.png",
+    "scope": "global",
+    "folder": "o8nGPmux6bWEpn9M",
+    "_key": "!macros!HuT2nQAgESxzj5wG",
+    "command_source": "packs_source/weaponfx/Effects (Manual)/DivinePunishment_HuT2nQAgESxzj5wG.js"
+}

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -27,6 +27,11 @@ class ModuleApi {
         return LloydsAlgorithm.getCentroids(targetPoints, numGroups);
     }
 
+    static getSequencerPathVariant(partialSequencerPath) {
+        const pathsUnder = Sequencer.Database.getPathsUnder(partialSequencerPath);
+        return [partialSequencerPath, pathsUnder[Math.round((pathsUnder.length - 1) * Math.random())]].join(".");
+    }
+
     static getMacroVariables = getMacroVariables;
     static euclideanDistance = euclideanDistance;
 }


### PR DESCRIPTION
When firing a missile weapon at multiple targets, if the user has the premium JB2A module active, the missile colors would be randomised. For example, one 'salvo' could include orange, blue, and green missiles, which looks silly! Instead, pick a single color at the start of the script, and use it for all missiles in the sequence.

This is used to implement a new "divine punishment" (Monarch core power) manual macro:

[divine_punishment.webm](https://github.com/user-attachments/assets/be0ac66d-b560-4fd6-b6db-17d621fa0092)
