### PR TITLE
Easier manual testing

### DIFF
--- a/packs_source/weaponfx/Effects (Manual)/DivinePunishment_HuT2nQAgESxzj5wG.js
+++ b/packs_source/weaponfx/Effects (Manual)/DivinePunishment_HuT2nQAgESxzj5wG.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 const pathVariantMissile = game.modules.get("lancer-weapon-fx").api.getSequencerPathVariant("jb2a.pack_hound_missile");
 

--- a/packs_source/weaponfx/Effects (Manual)/DivinePunishment_HuT2nQAgESxzj5wG.js
+++ b/packs_source/weaponfx/Effects (Manual)/DivinePunishment_HuT2nQAgESxzj5wG.js
@@ -10,10 +10,11 @@ await Sequencer.Preloader.preloadForClients([
     "modules/lancer-weapon-fx/soundfx/Missile_Impact.ogg",
 ]);
 
-let sequence = new Sequence();
-
-for (let i = 0; i < targetTokens.length; i++) {
-    let target = targetTokens[i];
+const sequences = targetTokens.map((target, i) => {
+    const sequence = new Sequence();
+    if (i) {
+        sequence.wait(175 * i);
+    }
     sequence
         .sound()
             .file("modules/lancer-weapon-fx/soundfx/Missile_Launch.ogg")
@@ -31,14 +32,14 @@ for (let i = 0; i < targetTokens.length; i++) {
             .atLocation(sourceToken)
             .stretchTo(target)
             .missed(targetsMissed.has(target.id))
-            .name(`impact${i}`)
+            .name("impact")
             .waitUntilFinished(-3200);
     sequence
         .effect()
             .xray(game.modules.get("lancer-weapon-fx").api.isEffectIgnoreFogOfWar())
             .aboveInterface(game.modules.get("lancer-weapon-fx").api.isEffectIgnoreLightingColoration())
             .file("jb2a.explosion.01.orange")
-            .atLocation(`impact${i}`)
+            .atLocation("impact")
             .scale(0.8)
             .zIndex(1)
             .waitUntilFinished(-1300);
@@ -50,5 +51,7 @@ for (let i = 0; i < targetTokens.length; i++) {
                 .volume(game.modules.get("lancer-weapon-fx").api.getEffectVolume(0.5))
                 .waitUntilFinished(-8500);
     }
-}
-sequence.play();
+    return sequence.play();
+});
+
+await Promise.all(sequences);

--- a/packs_source/weaponfx/Effects (Manual)/DivinePunishment_HuT2nQAgESxzj5wG.json
+++ b/packs_source/weaponfx/Effects (Manual)/DivinePunishment_HuT2nQAgESxzj5wG.json
@@ -1,0 +1,10 @@
+{
+    "_id": "HuT2nQAgESxzj5wG",
+    "name": "DivinePunishment",
+    "type": "script",
+    "img": "modules/lancer-weapon-fx/icons/missile-swarm.png",
+    "scope": "global",
+    "folder": "o8nGPmux6bWEpn9M",
+    "_key": "!macros!HuT2nQAgESxzj5wG",
+    "command_source": "packs_source/weaponfx/Effects (Manual)/DivinePunishment_HuT2nQAgESxzj5wG.js"
+}

--- a/packs_source/weaponfx/Effects (Manual)/JetLancerExplosion_WjxNFb3JQBla9BBC.js
+++ b/packs_source/weaponfx/Effects (Manual)/JetLancerExplosion_WjxNFb3JQBla9BBC.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients([
     "modules/lancer-weapon-fx/soundfx/dramaticSparkles.ogg",

--- a/packs_source/weaponfx/Effects (Manual)/MissileAirBurst_1ntDWMtnxAA1uZMH.js
+++ b/packs_source/weaponfx/Effects (Manual)/MissileAirBurst_1ntDWMtnxAA1uZMH.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 const pTarget = game.modules.get("lancer-weapon-fx").api.getTargetLocationsFromTokenGroup(targetTokens, 1)[0];
 

--- a/packs_source/weaponfx/Effects (Manual)/MissileAoE_HOn4Xub4x5q0AmPw.js
+++ b/packs_source/weaponfx/Effects (Manual)/MissileAoE_HOn4Xub4x5q0AmPw.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 const target = game.modules.get("lancer-weapon-fx").api.getTargetLocationsFromTokenGroup(targetTokens, 1)[0];
 

--- a/packs_source/weaponfx/Effects (Manual)/PlasmaProjector_7S31ONuehIUe8R0Q.js
+++ b/packs_source/weaponfx/Effects (Manual)/PlasmaProjector_7S31ONuehIUe8R0Q.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 const target = targetTokens[0];
 

--- a/packs_source/weaponfx/Effects (Manual)/Power_Knuckle_oGArtZBtIRBcRHCh.js
+++ b/packs_source/weaponfx/Effects (Manual)/Power_Knuckle_oGArtZBtIRBcRHCh.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients([
     "jb2a.unarmed_strike.physical.02.blue",

--- a/packs_source/weaponfx/Effects/AMR_RPjF4SvsMP3dolyX.js
+++ b/packs_source/weaponfx/Effects/AMR_RPjF4SvsMP3dolyX.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients([
     "modules/lancer-weapon-fx/soundfx/WeaponClick.ogg",

--- a/packs_source/weaponfx/Effects/Annihilator_XYVkQ3LALbGc6B7i.js
+++ b/packs_source/weaponfx/Effects/Annihilator_XYVkQ3LALbGc6B7i.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients([
     "modules/lancer-weapon-fx/soundfx/Annihilator_Charge.ogg",

--- a/packs_source/weaponfx/Effects/Apocalypse_Rail_Ui60K7EYoOV23KNM.js
+++ b/packs_source/weaponfx/Effects/Apocalypse_Rail_Ui60K7EYoOV23KNM.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 const target = game.modules.get("lancer-weapon-fx").api.getTargetLocationsFromTokenGroup(targetTokens, 1)[0];
 

--- a/packs_source/weaponfx/Effects/ArcBow_SvEgMaioDs6CiqaK.js
+++ b/packs_source/weaponfx/Effects/ArcBow_SvEgMaioDs6CiqaK.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 const findFarthestTargetOfGroup = function (targetTokens) {
     let farthestToken = null;

--- a/packs_source/weaponfx/Effects/Assault_Rifle_R006179gUEan7xqn.js
+++ b/packs_source/weaponfx/Effects/Assault_Rifle_R006179gUEan7xqn.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients(["modules/lancer-weapon-fx/soundfx/AR_Fire.ogg", "jb2a.bullet.01.orange"]);
 

--- a/packs_source/weaponfx/Effects/AssimilationMaw_JDu8MtHJgZSjN6TQ.js
+++ b/packs_source/weaponfx/Effects/AssimilationMaw_JDu8MtHJgZSjN6TQ.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients([
     "modules/lancer-weapon-fx/soundfx/Melee.ogg",

--- a/packs_source/weaponfx/Effects/AutoPod_JMFCQVUjBc3QLBpS.js
+++ b/packs_source/weaponfx/Effects/AutoPod_JMFCQVUjBc3QLBpS.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients([
     "modules/lancer-weapon-fx/soundfx/Autopod_Fire.ogg",

--- a/packs_source/weaponfx/Effects/BattleRifle_DdNSH1DTIsRyJCK9.js
+++ b/packs_source/weaponfx/Effects/BattleRifle_DdNSH1DTIsRyJCK9.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients([
     "modules/lancer-weapon-fx/soundfx/BR_Fire.ogg",

--- a/packs_source/weaponfx/Effects/BlastPick_blc8AUjYhehKKhc5.js
+++ b/packs_source/weaponfx/Effects/BlastPick_blc8AUjYhehKKhc5.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients([
     "jb2a.melee_generic.slash.01.orange",

--- a/packs_source/weaponfx/Effects/Bolt_Thrower_6lzGhwqHNYxXY25N.js
+++ b/packs_source/weaponfx/Effects/Bolt_Thrower_6lzGhwqHNYxXY25N.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients([
     "modules/lancer-weapon-fx/soundfx/shotgun_fire.ogg",

--- a/packs_source/weaponfx/Effects/Brood_Siblings_Molt_qfPYlbW1NHKOEJXF.js
+++ b/packs_source/weaponfx/Effects/Brood_Siblings_Molt_qfPYlbW1NHKOEJXF.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients([
     "jb2a.melee_attack.03.greatsword",

--- a/packs_source/weaponfx/Effects/Burst_Launcher_EHls7n7amW2fEZ97.js
+++ b/packs_source/weaponfx/Effects/Burst_Launcher_EHls7n7amW2fEZ97.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 const target = targetTokens[0];
 

--- a/packs_source/weaponfx/Effects/CannonAirburst_FL83T6qsM9zFOdAQ.js
+++ b/packs_source/weaponfx/Effects/CannonAirburst_FL83T6qsM9zFOdAQ.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 const pTarget = game.modules.get("lancer-weapon-fx").api.getTargetLocationsFromTokenGroup(targetTokens, 1)[0];
 

--- a/packs_source/weaponfx/Effects/Charged_Blade_kozGi0iZPK18rFlI.js
+++ b/packs_source/weaponfx/Effects/Charged_Blade_kozGi0iZPK18rFlI.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients([
     "jb2a.melee_attack.01.magic_sword.yellow",

--- a/packs_source/weaponfx/Effects/Combat_Drill_Tyi49hWX1axZsrq2.js
+++ b/packs_source/weaponfx/Effects/Combat_Drill_Tyi49hWX1axZsrq2.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients([
     "modules/lancer-weapon-fx/sprites/DRILL.png",

--- a/packs_source/weaponfx/Effects/Critical_Reactor_Failure_a7DXxn79DVbAPaUr.js
+++ b/packs_source/weaponfx/Effects/Critical_Reactor_Failure_a7DXxn79DVbAPaUr.js
@@ -1,4 +1,6 @@
-const { sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 const pivotx = token.document.flags["hex-size-support"]?.pivotx || 0;
 const ipivotx = -pivotx;

--- a/packs_source/weaponfx/Effects/Crushing_Hit_5ca9voXKeVdi65Jq.js
+++ b/packs_source/weaponfx/Effects/Crushing_Hit_5ca9voXKeVdi65Jq.js
@@ -1,4 +1,6 @@
-const { sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 const pivotx = token.document.flags["hex-size-support"]?.pivotx || 0;
 const ipivotx = -pivotx;

--- a/packs_source/weaponfx/Effects/Cyclone_Pulse_Rifle_1me7RVE8gdTnu9lk.js
+++ b/packs_source/weaponfx/Effects/Cyclone_Pulse_Rifle_1me7RVE8gdTnu9lk.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients([
     "modules/lancer-weapon-fx/soundfx/CPR_Fire.ogg",

--- a/packs_source/weaponfx/Effects/DD_288_XVCMT31Y9x5NgCf6.js
+++ b/packs_source/weaponfx/Effects/DD_288_XVCMT31Y9x5NgCf6.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients([
     "modules/lancer-weapon-fx/soundfx/DD288Full.ogg",

--- a/packs_source/weaponfx/Effects/DefaultMelee_JRAC43fdq4sRWQl8.js
+++ b/packs_source/weaponfx/Effects/DefaultMelee_JRAC43fdq4sRWQl8.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients([
     "jb2a.melee_generic.slash.01.orange",

--- a/packs_source/weaponfx/Effects/DefaultTech_nCYIyBz5RESLVDdt.js
+++ b/packs_source/weaponfx/Effects/DefaultTech_nCYIyBz5RESLVDdt.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients([
     "modules/lancer-weapon-fx/soundfx/TechPrepare.ogg",

--- a/packs_source/weaponfx/Effects/Destabilized_Power_Plant_wrf2itcyUdhhtp10.js
+++ b/packs_source/weaponfx/Effects/Destabilized_Power_Plant_wrf2itcyUdhhtp10.js
@@ -1,4 +1,6 @@
-const { sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 const pivotx = token.document.flags["hex-size-support"]?.pivotx || 0;
 const ipivotx = -pivotx;

--- a/packs_source/weaponfx/Effects/Direct_Hit_1_Ve9GIWf7kSiigqWe.js
+++ b/packs_source/weaponfx/Effects/Direct_Hit_1_Ve9GIWf7kSiigqWe.js
@@ -1,4 +1,6 @@
-const { sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients([
     "modules/lancer-weapon-fx/advisories/DirectHit.svg",

--- a/packs_source/weaponfx/Effects/Direct_Hit_2_SvcZLX9gpQVvBCiz.js
+++ b/packs_source/weaponfx/Effects/Direct_Hit_2_SvcZLX9gpQVvBCiz.js
@@ -1,4 +1,6 @@
-const { sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients([
     "modules/lancer-weapon-fx/advisories/DirectHit.svg",

--- a/packs_source/weaponfx/Effects/Displacer_IrU7oILyUlyEecJs.js
+++ b/packs_source/weaponfx/Effects/Displacer_IrU7oILyUlyEecJs.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 const pTarget = game.modules.get("lancer-weapon-fx").api.getTargetLocationsFromTokenGroup(targetTokens, 1)[0];
 

--- a/packs_source/weaponfx/Effects/DisruptorWhip_sdz6igpK2LGYTJfY.js
+++ b/packs_source/weaponfx/Effects/DisruptorWhip_sdz6igpK2LGYTJfY.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients([
     "jb2a.divine_smite.target.blueyellow",

--- a/packs_source/weaponfx/Effects/Emergency_Shunt_PqOetB3o4alRMk7d.js
+++ b/packs_source/weaponfx/Effects/Emergency_Shunt_PqOetB3o4alRMk7d.js
@@ -1,4 +1,6 @@
-const { sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 const pivotx = token.document.flags["hex-size-support"]?.pivotx || 0;
 const ipivotx = -pivotx;

--- a/packs_source/weaponfx/Effects/Flamethrower_uOyi8zHzCseXGQSR.js
+++ b/packs_source/weaponfx/Effects/Flamethrower_uOyi8zHzCseXGQSR.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 const target = game.modules.get("lancer-weapon-fx").api.getTargetLocationsFromTokenGroup(targetTokens, 1)[0];
 

--- a/packs_source/weaponfx/Effects/Flechette_Launcher_4znqR8pQvSs3KpZo.js
+++ b/packs_source/weaponfx/Effects/Flechette_Launcher_4znqR8pQvSs3KpZo.js
@@ -1,4 +1,6 @@
-const { sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients([
     "modules/lancer-weapon-fx/soundfx/Flechette.ogg",

--- a/packs_source/weaponfx/Effects/Fuel_Rod_Gun_5B4QaBx52NzRhdum.js
+++ b/packs_source/weaponfx/Effects/Fuel_Rod_Gun_5B4QaBx52NzRhdum.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 const target = targetTokens[0];
 

--- a/packs_source/weaponfx/Effects/Glancing_Blow_Y3Wr42OhV4dX4OrG.js
+++ b/packs_source/weaponfx/Effects/Glancing_Blow_Y3Wr42OhV4dX4OrG.js
@@ -1,4 +1,6 @@
-const { sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients([
     "modules/lancer-weapon-fx/advisories/GlancingBlow.svg",

--- a/packs_source/weaponfx/Effects/HMG_X6m0372eLE56NK6l.js
+++ b/packs_source/weaponfx/Effects/HMG_X6m0372eLE56NK6l.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients([
     "modules/lancer-weapon-fx/soundfx/AssaultCannonFire.ogg",

--- a/packs_source/weaponfx/Effects/Hammer_uIr2lCpJWXbDaowG.js
+++ b/packs_source/weaponfx/Effects/Hammer_uIr2lCpJWXbDaowG.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 let sequence = new Sequence();
 await Sequencer.Preloader.preloadForClients([

--- a/packs_source/weaponfx/Effects/Impact_Lance_gciDprfhVSDqYDPd.js
+++ b/packs_source/weaponfx/Effects/Impact_Lance_gciDprfhVSDqYDPd.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients([
     "modules/lancer-weapon-fx/soundfx/Annihilator_Charge.ogg",

--- a/packs_source/weaponfx/Effects/Irreversible_Meltdown_NOSrDkl2OasBwB9Z.js
+++ b/packs_source/weaponfx/Effects/Irreversible_Meltdown_NOSrDkl2OasBwB9Z.js
@@ -1,4 +1,6 @@
-const { sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 const pivotx = token.document.flags["hex-size-support"]?.pivotx || 0;
 const ipivotx = -pivotx;

--- a/packs_source/weaponfx/Effects/Kraul_Rifle_eyeOAl8lFp0w3Hfd.js
+++ b/packs_source/weaponfx/Effects/Kraul_Rifle_eyeOAl8lFp0w3Hfd.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 const target = targetTokens[0];
 

--- a/packs_source/weaponfx/Effects/Lasers_hWPrLPzlj6Y5RvC5.js
+++ b/packs_source/weaponfx/Effects/Lasers_hWPrLPzlj6Y5RvC5.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 const random = Sequencer.Helpers.random_float_between(200, 300);
 

--- a/packs_source/weaponfx/Effects/Latch_Drone_zf87PAIPccMpxnYn.js
+++ b/packs_source/weaponfx/Effects/Latch_Drone_zf87PAIPccMpxnYn.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients([
     "modules/lancer-weapon-fx/sprites/LatchDrone.png",

--- a/packs_source/weaponfx/Effects/Leviathan_UhdlCUxGv5UJGPQG.js
+++ b/packs_source/weaponfx/Effects/Leviathan_UhdlCUxGv5UJGPQG.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients([
     "modules/lancer-weapon-fx/soundfx/Leviathan.ogg",

--- a/packs_source/weaponfx/Effects/LockOn_k5UDriYBR2pnAUjn.js
+++ b/packs_source/weaponfx/Effects/LockOn_k5UDriYBR2pnAUjn.js
@@ -1,4 +1,6 @@
-const { targetTokens } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetTokens } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients([
     "modules/lancer-weapon-fx/soundfx/LockOn.ogg",

--- a/packs_source/weaponfx/Effects/Meltdown_EjhXUapgr82imuAa.js
+++ b/packs_source/weaponfx/Effects/Meltdown_EjhXUapgr82imuAa.js
@@ -1,4 +1,6 @@
-const { sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 const pivotx = token.document.flags["hex-size-support"]?.pivotx || 0;
 const ipivotx = -pivotx;

--- a/packs_source/weaponfx/Effects/MissilePinaka_nigj4bbJZOVrFf0u.js
+++ b/packs_source/weaponfx/Effects/MissilePinaka_nigj4bbJZOVrFf0u.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 // Pinaka wants 2 missiles, so get 2 groups
 const targetPoints = game.modules.get("lancer-weapon-fx").api.getTargetLocationsFromTokenGroup(targetTokens, 2);

--- a/packs_source/weaponfx/Effects/Missile_4M655uuaKwHfZJfZ.js
+++ b/packs_source/weaponfx/Effects/Missile_4M655uuaKwHfZJfZ.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 const target = game.modules.get("lancer-weapon-fx").api.getTargetLocationsFromTokenGroup(targetTokens, 1)[0];
 

--- a/packs_source/weaponfx/Effects/Missiles_bfFuD6eL09TcBLIN.js
+++ b/packs_source/weaponfx/Effects/Missiles_bfFuD6eL09TcBLIN.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 const pathVariantMissile = game.modules.get("lancer-weapon-fx").api.getSequencerPathVariant("jb2a.pack_hound_missile");
 

--- a/packs_source/weaponfx/Effects/Mortar_sSGstellhxzWUTXd.js
+++ b/packs_source/weaponfx/Effects/Mortar_sSGstellhxzWUTXd.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 const centerMass = game.modules.get("lancer-weapon-fx").api.getTargetLocationsFromTokenGroup(targetTokens, 1)[0];
 

--- a/packs_source/weaponfx/Effects/Nanobot_Whip_jHll38UQ9hHzwsf3.js
+++ b/packs_source/weaponfx/Effects/Nanobot_Whip_jHll38UQ9hHzwsf3.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients([
     "jb2a.divine_smite.target.blueyellow",

--- a/packs_source/weaponfx/Effects/Needle_Beam_Aj3QspxsjcnNjfol.js
+++ b/packs_source/weaponfx/Effects/Needle_Beam_Aj3QspxsjcnNjfol.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients([
     "modules/lancer-weapon-fx/soundfx/Annihilator_Charge.ogg",

--- a/packs_source/weaponfx/Effects/Nexus_RmFiCRMoSOku7G5g.js
+++ b/packs_source/weaponfx/Effects/Nexus_RmFiCRMoSOku7G5g.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 const pTarget = game.modules.get("lancer-weapon-fx").api.getTargetLocationsFromTokenGroup(targetTokens, 1)[0];
 

--- a/packs_source/weaponfx/Effects/Overcharge_QAV4DZC2jNCCsigl.js
+++ b/packs_source/weaponfx/Effects/Overcharge_QAV4DZC2jNCCsigl.js
@@ -1,4 +1,6 @@
-const { sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 const pivotx = token.document.flags["hex-size-support"]?.pivotx || 0;
 const ipivotx = -pivotx;

--- a/packs_source/weaponfx/Effects/PPC_LxQMeItXellYRt3b.js
+++ b/packs_source/weaponfx/Effects/PPC_LxQMeItXellYRt3b.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients([
     "modules/lancer-weapon-fx/soundfx/PPC2.ogg",

--- a/packs_source/weaponfx/Effects/Pistol_OSMfNiiu5XtzacAJ.js
+++ b/packs_source/weaponfx/Effects/Pistol_OSMfNiiu5XtzacAJ.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 const random = Sequencer.Helpers.random_float_between(300, 500);
 

--- a/packs_source/weaponfx/Effects/Plasma_Maul_gBqPs99uLDUAroZu.js
+++ b/packs_source/weaponfx/Effects/Plasma_Maul_gBqPs99uLDUAroZu.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients([
     "jb2a.melee_attack.03.maul.01",

--- a/packs_source/weaponfx/Effects/Plasma_Rifle_noDQfz2lYaqIc1ii.js
+++ b/packs_source/weaponfx/Effects/Plasma_Rifle_noDQfz2lYaqIc1ii.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 const random = Sequencer.Helpers.random_float_between(300, 400);
 

--- a/packs_source/weaponfx/Effects/Plasma_Talons_ui1a07lCGBOk4Rp7.js
+++ b/packs_source/weaponfx/Effects/Plasma_Talons_ui1a07lCGBOk4Rp7.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients([
     "jb2a.claws.400px.red",

--- a/packs_source/weaponfx/Effects/Plasma_Thrower_e5XwWrHsiRKrgh7S.js
+++ b/packs_source/weaponfx/Effects/Plasma_Thrower_e5XwWrHsiRKrgh7S.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 const target = game.modules.get("lancer-weapon-fx").api.getTargetLocationsFromTokenGroup(targetTokens, 1)[0];
 

--- a/packs_source/weaponfx/Effects/Plasma_Torch_UL0licrIIu44WXnO.js
+++ b/packs_source/weaponfx/Effects/Plasma_Torch_UL0licrIIu44WXnO.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 const target = targetTokens[0];
 

--- a/packs_source/weaponfx/Effects/Power_Failure_nUA4TUbz5Ocb7ny5.js
+++ b/packs_source/weaponfx/Effects/Power_Failure_nUA4TUbz5Ocb7ny5.js
@@ -1,4 +1,6 @@
-const { sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 const pivotx = token.document.flags["hex-size-support"]?.pivotx || 0;
 const ipivotx = -pivotx;

--- a/packs_source/weaponfx/Effects/Pre_System_Trauma_tmK1gddkTSmKuOg8.js
+++ b/packs_source/weaponfx/Effects/Pre_System_Trauma_tmK1gddkTSmKuOg8.js
@@ -1,4 +1,6 @@
-const { sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients([
     "modules/lancer-weapon-fx/advisories/SystemTrauma.svg",

--- a/packs_source/weaponfx/Effects/Railgun_iOD860W9KokfR3Hy.js
+++ b/packs_source/weaponfx/Effects/Railgun_iOD860W9KokfR3Hy.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 const findFarthestTargetOfGroup = function (targetTokens) {
     let farthestToken = null;

--- a/packs_source/weaponfx/Effects/Retort_Loop_NbTm6IW88EKyM6sN.js
+++ b/packs_source/weaponfx/Effects/Retort_Loop_NbTm6IW88EKyM6sN.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients([
     "modules/lancer-weapon-fx/soundfx/RetortLoop.ogg",

--- a/packs_source/weaponfx/Effects/ShockBaton_POS2lrr0O83sNweN.js
+++ b/packs_source/weaponfx/Effects/ShockBaton_POS2lrr0O83sNweN.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients([
     "jb2a.melee_attack.01.magic_sword.yellow",

--- a/packs_source/weaponfx/Effects/Shock_Claws_gU5BP1wousYVM6jS.js
+++ b/packs_source/weaponfx/Effects/Shock_Claws_gU5BP1wousYVM6jS.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 const targetToken = game.user.targets.first();
 

--- a/packs_source/weaponfx/Effects/Shotgun_NMU9syMKa0dTsINf.js
+++ b/packs_source/weaponfx/Effects/Shotgun_NMU9syMKa0dTsINf.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients([
     "modules/lancer-weapon-fx/soundfx/shotgun_cycle.ogg",

--- a/packs_source/weaponfx/Effects/Shrapnel_Cannon_tiIQsogSvW5B4Wso.js
+++ b/packs_source/weaponfx/Effects/Shrapnel_Cannon_tiIQsogSvW5B4Wso.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 const pTarget = game.modules.get("lancer-weapon-fx").api.getTargetLocationsFromTokenGroup(targetTokens, 1)[0];
 

--- a/packs_source/weaponfx/Effects/Slag_Cannon_OAs6mALoTynun3lM.js
+++ b/packs_source/weaponfx/Effects/Slag_Cannon_OAs6mALoTynun3lM.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 const target = game.modules.get("lancer-weapon-fx").api.getTargetLocationsFromTokenGroup(targetTokens, 1)[0];
 

--- a/packs_source/weaponfx/Effects/Stabilize_77szM2o5ThaLsJax.js
+++ b/packs_source/weaponfx/Effects/Stabilize_77szM2o5ThaLsJax.js
@@ -1,4 +1,6 @@
-const { sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 const pivotx = token.document.flags["hex-size-support"]?.pivotx || 0;
 const ipivotx = -pivotx;

--- a/packs_source/weaponfx/Effects/System_Trauma_EGtaSw7oQsGz2sqZ.js
+++ b/packs_source/weaponfx/Effects/System_Trauma_EGtaSw7oQsGz2sqZ.js
@@ -1,4 +1,6 @@
-const { sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients([
     "jb2a.explosion_side.01.orange.1",

--- a/packs_source/weaponfx/Effects/Tachyon_Lance_BkYGErIuWCVcF4rS.js
+++ b/packs_source/weaponfx/Effects/Tachyon_Lance_BkYGErIuWCVcF4rS.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients([
     "modules/lancer-weapon-fx/soundfx/Annihilator_Charge.ogg",

--- a/packs_source/weaponfx/Effects/TempestBlade_hI3KpcI1IYKR43lF.js
+++ b/packs_source/weaponfx/Effects/TempestBlade_hI3KpcI1IYKR43lF.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients([
     "jb2a.melee_attack.01.magic_sword.yellow",

--- a/packs_source/weaponfx/Effects/Thermal_Rifle_LixHY6HTrY7D3b7S.js
+++ b/packs_source/weaponfx/Effects/Thermal_Rifle_LixHY6HTrY7D3b7S.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients([
     "modules/lancer-weapon-fx/soundfx/WeaponBeep.ogg",

--- a/packs_source/weaponfx/Effects/Torch_zsccsSD1tOOqRc5Q.js
+++ b/packs_source/weaponfx/Effects/Torch_zsccsSD1tOOqRc5Q.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients([
     "jb2a.greataxe.melee.standard.white",

--- a/packs_source/weaponfx/Effects/Veil_Rifle_6vtYP47LXaX5POYB.js
+++ b/packs_source/weaponfx/Effects/Veil_Rifle_6vtYP47LXaX5POYB.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 const findFarthestTargetOfGroup = function (targetTokens) {
     let farthestToken = null;

--- a/packs_source/weaponfx/Effects/War_Pike_CqlCKrYyJCYdmLks.js
+++ b/packs_source/weaponfx/Effects/War_Pike_CqlCKrYyJCYdmLks.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 await Sequencer.Preloader.preloadForClients([
     "jb2a.spear.melee.01.white.2",

--- a/packs_source/weaponfx/Effects/Warp_Rifle_jGNjJXWRQMh7jPhA.js
+++ b/packs_source/weaponfx/Effects/Warp_Rifle_jGNjJXWRQMh7jPhA.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 const target = targetTokens[0];
 

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -27,6 +27,11 @@ class ModuleApi {
         return LloydsAlgorithm.getCentroids(targetPoints, numGroups);
     }
 
+    static getSequencerPathVariant(partialSequencerPath) {
+        const pathsUnder = Sequencer.Database.getPathsUnder(partialSequencerPath);
+        return [partialSequencerPath, pathsUnder[Math.round((pathsUnder.length - 1) * Math.random())]].join(".");
+    }
+
     static getMacroVariables = getMacroVariables;
     static euclideanDistance = euclideanDistance;
 }

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -31,8 +31,8 @@ export function getUniquePoints(points) {
     });
 }
 
-export function getMacroVariables(macro = null) {
-    const sourceTokenFallback = canvas.tokens.controlled[0] ?? game.combat?.current?.tokenId;
+export function getMacroVariables(macro = null, token = null) {
+    const sourceTokenFallback = token ?? canvas.tokens.controlled[0] ?? game.combat?.current?.tokenId;
     const targetsFallback = [...game.user.targets];
     const flowInfo = macro?.flags?.[MODULE_ID]?.flowInfo;
 

--- a/tooling/effect.template.js
+++ b/tooling/effect.template.js
@@ -1,4 +1,6 @@
-const { targetsMissed, targetTokens, sourceToken } = game.modules.get("lancer-weapon-fx").api.getMacroVariables(this);
+const { targetsMissed, targetTokens, sourceToken } = game.modules
+    .get("lancer-weapon-fx")
+    .api.getMacroVariables(this, typeof token !== "undefined" ? token : null);
 
 const sequence = new Sequence();
 


### PR DESCRIPTION
Pass in the default `token` to macros which are run manually. This makes manual testing easier by using the user's token as a fallback when no token is selected.

This is a branch from #87, which should be merged first!